### PR TITLE
Check vagrant requirement and assume loading this plugin normally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', github: 'mitchellh/vagrant'
+  gem 'vagrant', github: 'hashicorp/vagrant'
 end
 
 group :plugins do

--- a/lib/vagrant-trellis-cert.rb
+++ b/lib/vagrant-trellis-cert.rb
@@ -1,4 +1,17 @@
 # frozen_string_literal: true
 
+begin
+  require 'vagrant'
+rescue LoadError
+  raise 'The Vagrant Trellis Cert plugin must be run within Vagrant.'
+end
+
+# This is a sanity check to make sure no one is attempting to install
+# this into an early Vagrant version.
+# Requiring 1.9.6 or later because of Ruby 2.3
+if Vagrant::VERSION < '1.9.6'
+  raise 'The Vagrant Trellis Cert plugin is only compatible with Vagrant 1.9.6 or later'
+end
+
 require 'vagrant_plugins/trellis_cert/identity'
 require 'vagrant_plugins/trellis_cert/plugin'

--- a/lib/vagrant_plugins/trellis_cert/commands/root.rb
+++ b/lib/vagrant_plugins/trellis_cert/commands/root.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'optparse'
-require 'vagrant'
 
 module VagrantPlugins
   module TrellisCert

--- a/lib/vagrant_plugins/trellis_cert/commands/trust.rb
+++ b/lib/vagrant_plugins/trellis_cert/commands/trust.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'fileutils'
-require 'optparse'
-require 'vagrant'
 require 'vagrant_plugins/trellis_cert/trellis'
 
 module VagrantPlugins

--- a/lib/vagrant_plugins/trellis_cert/plugin.rb
+++ b/lib/vagrant_plugins/trellis_cert/plugin.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'vagrant'
-
 module VagrantPlugins
   module TrellisCert
     class Plugin < Vagrant.plugin('2')

--- a/lib/vagrant_plugins/trellis_cert/trellis.rb
+++ b/lib/vagrant_plugins/trellis_cert/trellis.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'vagrant'
 require 'yaml'
 
 module VagrantPlugins


### PR DESCRIPTION
- Assume loading this plugin normally, i.e.: not loading individual file directly
- Fail if running outside of vagrant
- Fail unless vagrant version is 1.9.6 or later