### PR TITLE
Add troubleshooting section with getaddrrinfo error

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Ready to take freelance WordPress jobs. Contact me via the contact form [here](h
 
 Contact: [Tang Rufus](mailto:tangrufus@gmail.com)
 
+## Troubleshooting
+
+`getaddrinfo: nodename nor servname provided, or not known`
+
+Make sure your hosts file contains all urls you're self-signing.
+
 ## Feedback
 
 **Please provide feedback!** We want to make this library useful in as many projects as possible.


### PR DESCRIPTION
@TangRufus came across this myself, I know Trellis/vagrant-hostmanager is supposed to handle this for you but somehow on my setup I had one URL not added to the hosts file even after a reload. Might save a few people a bit of time. If there's somewhere else this should go let me know.